### PR TITLE
Fixing google docs key regex

### DIFF
--- a/scripts/wtf.js
+++ b/scripts/wtf.js
@@ -13,7 +13,7 @@ var WTF = (function() {
 
     var RE_QUOTE = /\"([^\"]+)\"/gi;
     var RE_JSON = /\.json$/i;
-    var RE_KEY = /[a-z0-9]{32,}/i;
+    var RE_KEY = /[a-z0-9_-]{32,}/i;
     var DOCS_PATH = 'https://docs.google.com/spreadsheet/pub?key={key}&output=csv';
 
     var templates;


### PR DESCRIPTION
Some google docs have an underscore and/or a dash in the key. [See this doc for an example.](https://docs.google.com/spreadsheet/ccc?key=0AoCe6lq_0U-_dEhQTHlRT0VDTGtVZWhIa21iQUdDVnc&usp=sharing) This patch supports those docs.
