### PR TITLE
Fixed "WTF Are My Weekend Plans" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ As you can see, in a template you use the __@__ symbol, followed by the type of 
 
 I've been pleasantly surprised to find several people using this template to create their own sites. Among them are:
 
-- [WTF Are My Weekend Plans](www.wtfplans.com)
+- [WTF Are My Weekend Plans](http://www.wtfplans.com/)
 - [What The Fuck Is My Hydration Strategy](http://theplan.co.uk/hydration/)
 - [What The Fuck Is Birmingham's Transport Strategy](http://toys.paradisecircus.com/transport/)
 - [What's your fucking weapon](http://scottyboy76567.github.io/WeaponGenerator/)


### PR DESCRIPTION
wtfplans was redirecting to: `https://github.com/soulwire/WTFEngine/blob/master/www.wtfplans.com` because it didn't have `http://`.

Just added http to the front to fix it.
