### PR TITLE
Fix bug with conflicting names.

### DIFF
--- a/scripts/wtf.js
+++ b/scripts/wtf.js
@@ -164,6 +164,13 @@ var WTF = (function() {
 
             types.push( type );
 
+        types = types.sort(function (a, b) {
+            if (a.length == b.length) {
+                return 0
+            }
+            return a.length > b.length ? -1 : 1
+        })
+        
         var content = '@(type)'.replace( 'type', types.join( '|' ) );
 
         regex = new RegExp( content, 'gi' );


### PR DESCRIPTION
If you have @pop and @popcorn then with "I'd like a @pop and @popcorn" you can end up with "I'd like a Coke and Pepsicorn" instead of "I'd like a Coke and a Caramel Corn".